### PR TITLE
Close the connection on the server when the client closes it first

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -69,7 +69,7 @@ func (conn *Conn) Serve() {
 		line, err := conn.controlReader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
-				continue
+				break
 			}
 
 			conn.logger.Print(fmt.Sprintln("read error:", err))


### PR DESCRIPTION
When the client closes the connection, the server will read EOF. In that case the connection should be closed on the server as well. Without this change the server goroutine will go into an infinite loop when the client closes the connection. It'll try to read, get an EOF, then "continue", go back to read, get another EOF and so on. That takes 100% CPU in this situation.